### PR TITLE
Bug fix: Add ucode.proto to up-core-api source list

### DIFF
--- a/up-core-api/CMakeLists.txt
+++ b/up-core-api/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PROTO_FILES
 	up-core-api/uprotocol/v1/umessage.proto
 	up-core-api/uprotocol/v1/uri.proto
 	up-core-api/uprotocol/v1/ustatus.proto
+	up-core-api/uprotocol/v1/ucode.proto
 	up-core-api/uprotocol/v1/uuid.proto
 	up-core-api/uprotocol/core/udiscovery/v3/udiscovery.proto
 	up-core-api/uprotocol/core/usubscription/v3/usubscription.proto


### PR DESCRIPTION
Add ucode.proto file CMakeLists.txt

Fix for: https://github.com/eclipse-uprotocol/up-conan-recipes/issues/9#issue-2357511099