### PR TITLE
Adding (temporary) Zenoh C++ recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,18 @@ jobs:
         shell: bash
         run: |
           conan create --version 0.11.0.3 zenohc-tmp/prebuilt
+          conan create --version 0.11.0 zenohc-tmp/prebuilt
+
+      - name: Build zenohcpp conan package
+        shell: bash
+        run: |
+          conan create --version 0.11.0.3 zenohcpp-tmp/from-source
+          conan create --version 0.11.0 zenohcpp-tmp/from-source
 
       - name: Build up-transport-zenoh-cpp conan package
         shell: bash
         run: |
-          conan create --version 0.1.4 --build=missing up-transport-zenoh-cpp/developer
+          conan create --version 0.2.0 --build=missing up-transport-zenoh-cpp/developer
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/up-transport-zenoh-cpp/developer/conanfile.py
+++ b/up-transport-zenoh-cpp/developer/conanfile.py
@@ -28,7 +28,7 @@ class upZenohTransportRecipe(ConanFile):
             "fork": "eclipse-uprotocol/up-transport-zenoh-cpp",
             "commitish": "main"}
 
-    requires = "zenohc/0.11.0.3", "up-cpp/0.2.0", "up-core-api/[>=1.5.8]", "spdlog/[>=1.13.0]", "protobuf/[>=3.21.12]"
+    requires = "zenohcpp/0.11.0", "up-cpp/0.2.0", "up-core-api/[>=1.5.8]", "spdlog/[>=1.13.0]", "protobuf/[>=3.21.12]"
     test_requires = "gtest/1.14.0"
 
     def source(self):

--- a/zenohc-tmp/prebuilt/conandata.yml
+++ b/zenohc-tmp/prebuilt/conandata.yml
@@ -1,4 +1,12 @@
 sources:
+  "0.11.0":
+    "Linux":
+      "x86_64":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.11.0/zenoh-c-0.11.0-x86_64-unknown-linux-gnu-standalone.zip"
+        sha256: "eab23235f65b763280d45d3d4ba46a3a4c31fbd25f711c661440729735286469"
+    "license":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/raw/0.11.0/LICENSE"
+        sha256: "01a44774f7b1a453595c7c6d7f7308284ba6a1059dc49e14dad6647e1d44a338"
   "0.11.0.3":
     "Windows":
       "x86_64":

--- a/zenohcpp-tmp/from-source/conandata.yml
+++ b/zenohcpp-tmp/from-source/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "0.11.0":
+    url: "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/0.11.0.tar.gz"
+    sha256: "62e9a51ced89130d7a49a1e8f801308338d972e62b90c5224f5801171bd90af0"
+  "0.11.0.3":
+    url: "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/0.11.0.3.tar.gz"
+    sha256: "3c0a424809f464b9704480bca58c895a5438f4bb1586d4e3ff4838879c73b69d"

--- a/zenohcpp-tmp/from-source/conanfile.py
+++ b/zenohcpp-tmp/from-source/conanfile.py
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+from conan import ConanFile
+from conan.tools.files import copy, download, get
+from conan.tools.cmake import cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain
+
+import platform
+import os
+
+required_conan_version = ">=1.53.0"
+
+class ZenohCppPackageConan(ConanFile):
+    name = "zenohcpp"
+    description = "C++ API for Eclipse Zenoh: Zero Overhead Pub/Sub, Store/Query and Compute protocol"
+    tags = ["iot", "networking", "robotics", "messaging", "ros2", "edge-computing", "micro-controller", "header-only"]
+    license = "EPL-2.0 OR Apache-2.0"
+    author = "ZettaScale Zenoh Team <zenoh@zettascale.tech>"
+
+    url = "https://github.com/eclipse-zenoh/zenoh-cpp"
+    homepage = "https://github.com/eclipse-zenoh/zenoh-cpp"
+
+    package_type = "header-library"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    options = { }
+    default_options = { }
+    settings = "build_type"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires("zenohc/{}".format(self.version))
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.build_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.configure(build_script_folder="install")
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "zenohcpp")
+        self.cpp_info.set_property("cmake_target_name", "zenohcpp::lib")
+
+        self.cpp_info.includedirs = ["include"]


### PR DESCRIPTION
The updated version of up-transport-zenoh-cpp will be using zenoh-cpp. This adds a package for that and rolls zenoh-cpp/zenoh-c forward to the latest release.

Closes #12 