### PR TITLE
Fix issue with docker group membership detection

### DIFF
--- a/tools/ubuntu-24.04-docker/launch-shell.sh
+++ b/tools/ubuntu-24.04-docker/launch-shell.sh
@@ -5,7 +5,7 @@ CONTAINER_SCRIPTS="/data/recipes/tools/ubuntu-24.04-docker/.container_scripts"
 
 echo "Preparing to launch and configure Ubuntu 24.04 docker container"
 
-if [ -n "$(groups) | grep docker" ]; then
+if [ -z "$(groups | grep docker)" ]; then
 	echo "User not in docker group, sudo will be required"
 	echo
 	DOCKER_CMD="sudo docker"


### PR DESCRIPTION
The syntax was wrong so membership in the `docker` group was not detected. This resulted in unnecessarily requiring the use of `sudo` to issue docker commands.