### PR TITLE
Resolving issue with UID 1000 in the ubuntu 24.04 container

### DIFF
--- a/tools/ubuntu-24.04-docker/.container_scripts/configure.sh
+++ b/tools/ubuntu-24.04-docker/.container_scripts/configure.sh
@@ -18,6 +18,7 @@ dpkg -i conan-2.3.0-amd64.deb
 
 echo
 echo "Configuring container user"
+userdel ubuntu
 groupadd -g $GROUP_ID -o user
 useradd --shell /bin/bash -u $USER_ID -g $GROUP_ID -o -c "" -m user
 


### PR DESCRIPTION
When the external has a UID of 1000, the container will drop the user into the *ubuntu* account instead of our configured *user* account. This addresses that issue by removing the *ubuntu* user.