### PR TITLE
Replacing up-cpp 1.0.1-rc0 with rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,10 @@ jobs:
         run: |
           conan create --version 1.0.0-rc4 zenohcpp-tmp/from-source
 
-      - name: Build up-transport-zenoh-cpp conan package
-        shell: bash
-        run: |
-          conan create --version 1.0.0-dev --build=missing up-transport-zenoh-cpp/developer
+#      - name: Build up-transport-zenoh-cpp conan package
+#        shell: bash
+#        run: |
+#          conan create --version 1.0.0-dev --build=missing up-transport-zenoh-cpp/developer
 
       - name: List conan packages
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           conan create --version 1.0.0-rc0 --build=missing up-cpp/release
           conan create --version 1.0.0 --build=missing up-cpp/release
-          conan create --version 1.0.1-rc0 --build=missing up-cpp/release
+          conan create --version 1.0.1-rc1 --build=missing up-cpp/release
 
       - name: Build zenohc conan package
         shell: bash

--- a/up-cpp/release/conandata.yml
+++ b/up-cpp/release/conandata.yml
@@ -19,12 +19,10 @@
   test-requirements:
     gtest: "1.14.0"
 
-# NOTE: This is up-cpp PR #240. This will be replaced with the merged commit
-# once the PR is complete.
-1.0.1-rc0:
+1.0.1-rc1:
   sources:
-    url: "https://github.com/gregmedd/up-cpp/archive/d5cc19ef54bd47f9e9693a23d96e33d23e952bff.tar.gz"
-    sha256: "fbd5c100f6a9c954cfb512f57a2710cc317972b15875380b3cda8a1c2b25a192"
+    url: "https://github.com/eclipse-uprotocol/up-cpp/archive/9d53a0a0d318cf2a1ce3ab7ecc37198fa50f3941.tar.gz"
+    sha256: "f6753e5b25ddaa2eb224f6988f76f1b62bc7219a9b72bcdf51b07c498ef9178d"
   requirements:
     protobuf: "3.21.12"
     up-core-api: "1.6.0"


### PR DESCRIPTION
Now that the bugfix is committed, we can point to the official repo instead of a fork.