### PR TITLE
Updating CMAKE version to FILE_SET introduction

### DIFF
--- a/up-core-api/CMakeLists.txt
+++ b/up-core-api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.23)
 project(up-core-api VERSION 1.5.8 LANGUAGES CXX DESCRIPTION "uProtocol Core API")
 
 find_package(protobuf CONFIG REQUIRED)


### PR DESCRIPTION
FILE_SET was introduce in CMAKE 3.23 adding check to avoid any build errors (closes #8 )