### PR TITLE
Adding RC6 Zenoh packages, updating CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           conan create --version 0.11.0 zenohc-tmp/prebuilt
           conan create --version 1.0.0-rc4 zenohc-tmp/prebuilt
           conan create --version 1.0.0-rc5 zenohc-tmp/prebuilt
+          conan create --version 1.0.0-rc6 zenohc-tmp/prebuilt
 
       - name: Build zenohcpp conan package
         shell: bash
@@ -50,6 +51,7 @@ jobs:
           conan create --version 0.11.0 zenohcpp-tmp/from-source
           conan create --version 1.0.0-rc4 zenohcpp-tmp/from-source
           conan create --version 1.0.0-rc5 zenohcpp-tmp/from-source
+          conan create --version 1.0.0-rc6 zenohcpp-tmp/from-source
 
       - name: Build up-transport-zenoh-cpp conan package
         shell: bash
@@ -90,17 +92,17 @@ jobs:
       - name: Build zenohc conan package
         shell: bash
         run: |
-          conan create --version 1.0.0-rc4 zenohc-tmp/prebuilt
+          conan create --version 1.0.0-rc5 zenohc-tmp/prebuilt
 
       - name: Build zenohcpp conan package
         shell: bash
         run: |
-          conan create --version 1.0.0-rc4 zenohcpp-tmp/from-source
+          conan create --version 1.0.0-rc5 zenohcpp-tmp/from-source
 
-#      - name: Build up-transport-zenoh-cpp conan package
-#        shell: bash
-#        run: |
-#          conan create --version 1.0.0-dev --build=missing up-transport-zenoh-cpp/developer
+      - name: Build up-transport-zenoh-cpp conan package
+        shell: bash
+        run: |
+          conan create --version 1.0.0-dev --build=missing up-transport-zenoh-cpp/developer
 
       - name: Build up-transport-socket-cpp conan package
         shell: bash

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ At time of writing, conan packages were not available for zenoh-c and zenoh-cpp.
 They are prerequisites for the up-transport-zenoh-cpp packages. With Conan 2:
 
 ```
-conan create --version 1.0.0-rc4 zenohc-tmp/prebuilt
-conan create --version 1.0.0-rc4 zenohcpp-tmp/from-source
+conan create --version 1.0.0-rc5 zenohc-tmp/prebuilt
+conan create --version 1.0.0-rc5 zenohcpp-tmp/from-source
 ```
 
 ## Running in a clean docker container

--- a/zenohc-tmp/prebuilt/conandata.yml
+++ b/zenohc-tmp/prebuilt/conandata.yml
@@ -1,4 +1,12 @@
 sources:
+  "1.0.0-rc6":
+    "Linux":
+      "x86_64":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/1.0.0.6/zenoh-c-1.0.0.6-x86_64-unknown-linux-gnu-standalone.zip"
+        sha256: "2eaff1c0a0c735633b7bcf52971f78699a4e92b527888ecb95b82829d0b5cdd8"
+    "license":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/raw/1.0.0.6/LICENSE"
+        sha256: "01a44774f7b1a453595c7c6d7f7308284ba6a1059dc49e14dad6647e1d44a338"
   "1.0.0-rc5":
     "Linux":
       "x86_64":

--- a/zenohcpp-tmp/from-source/conandata.yml
+++ b/zenohcpp-tmp/from-source/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0-rc6":
+    url: "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/1.0.0.6.tar.gz"
+    sha256: "cb8ccadc9018312b6a27ae6df7b39795f2109291e5d06e9940de36428101a6ef"
   "1.0.0-rc5":
     url: "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/1.0.0.5.tar.gz"
     sha256: "99d8c281442b40c3dada43c63d0f04f848bc472407f9ee375a831e065f9c47e8"
@@ -12,6 +15,8 @@ sources:
     url: "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/0.11.0.3.tar.gz"
     sha256: "3c0a424809f464b9704480bca58c895a5438f4bb1586d4e3ff4838879c73b69d"
 build:
+  "1.0.0-rc6":
+    build_script_folder: "." 
   "1.0.0-rc5":
     build_script_folder: "." 
   "1.0.0-rc4":


### PR DESCRIPTION
zenoh-c and zenoh-cpp 1.0.0.6 have been released, so we can add those to the recipes.

Additionally, the current dev release of up-transport-zenoh-cpp relies on RC5 of zenohcpp.