### PR TITLE
Fixing release versions for up-core-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build up-core-api conan package
         shell: bash
         run: |
-          conan create --version 1.6.0 up-core-api/release
+          conan create --version 1.6.0-alpha2 up-core-api/release
 
       - name: Build up-cpp conan package
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         shell: bash
         run: |
           conan create --version 1.6.0-alpha2 up-core-api/release
+          conan create --version 1.6.0-alpha3 up-core-api/release
 
       - name: Build up-cpp conan package
         shell: bash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ out and built.
 With Conan 2:
 
 ```
-conan create --version 1.6.0 --build=missing up-core-api/release/
+conan create --version 1.6.0-alpha2 --build=missing up-core-api/release/
 conan create --version 1.0.0 --build=missing up-cpp/release/
 conan create --version 1.0.0-rc1 --build=missing up-transport-zenoh-cpp/release/
 ```

--- a/up-core-api/release/conandata.yml
+++ b/up-core-api/release/conandata.yml
@@ -1,4 +1,4 @@
-1.6.0:
+1.6.0-alpha2:
   sources:
     url: "https://github.com/eclipse-uprotocol/up-spec/archive/refs/tags/v1.6.0-alpha.2.tar.gz"
     sha256: "f0159c57d33aa3d148b5032d5f7f079e7eadc9588723a1ac581808b39e85ffdd"

--- a/up-core-api/release/conandata.yml
+++ b/up-core-api/release/conandata.yml
@@ -4,4 +4,10 @@
     sha256: "f0159c57d33aa3d148b5032d5f7f079e7eadc9588723a1ac581808b39e85ffdd"
   requirements:
     protobuf: "3.21.12"
+1.6.0-alpha3:
+  sources:
+    url: "https://github.com/eclipse-uprotocol/up-spec/archive/refs/tags/v1.6.0-alpha.3.tar.gz"
+    sha256: "ac51d1f5554dffa7b8eda28f075b5671a60a2656a5cef59e7843eddd6a44b9c6"
+  requirements:
+    protobuf: "3.21.12"
 

--- a/up-cpp/release/conandata.yml
+++ b/up-cpp/release/conandata.yml
@@ -4,7 +4,7 @@
     sha256: "f65fd40e3ba8914e70d3a4a9e5426b646ad6299c94841ff42a918fe75513e128"
   requirements:
     protobuf: "3.21.12"
-    up-core-api: "1.6.0"
+    up-core-api: "1.6.0-alpha2"
     spdlog: "1.13.0"
   test-requirements:
     gtest: "1.14.0"
@@ -15,7 +15,7 @@
     sha256: "295c2730155bd86e91b974321ed863bcfc3d7479686694543f69382ba22baa06"
   requirements:
     protobuf: "3.21.12"
-    up-core-api: "1.6.0"
+    up-core-api: "1.6.0-alpha2"
   test-requirements:
     gtest: "1.14.0"
 
@@ -25,6 +25,6 @@
     sha256: "f6753e5b25ddaa2eb224f6988f76f1b62bc7219a9b72bcdf51b07c498ef9178d"
   requirements:
     protobuf: "3.21.12"
-    up-core-api: "1.6.0"
+    up-core-api: "1.6.0-alpha2"
   test-requirements:
     gtest: "1.14.0"

--- a/up-transport-zenoh-cpp/release/conandata.yml
+++ b/up-transport-zenoh-cpp/release/conandata.yml
@@ -5,7 +5,7 @@
   requirements:
     zenohcpp: "0.11.0" 
     up-cpp: "1.0.0-rc0" 
-    up-core-api: "1.6.0" 
+    up-core-api: "1.6.0-alpha2"
     spdlog: "1.13.0" 
     protobuf: "3.21.12"
   test-requirements:
@@ -18,7 +18,7 @@
   requirements:
     zenohcpp: "1.0.0-rc4" 
     up-cpp: "1.0.0" 
-    up-core-api: "1.6.0" 
+    up-core-api: "1.6.0-alpha2"
     spdlog: "1.13.0" 
     protobuf: "3.21.12"
   test-requirements:


### PR DESCRIPTION
When the 1.6.0 release version was provided, we expected that future alpha releases to the core API would increment version numbers in the same way they had been before (1.6.0 -> 1.6.1 -> 1.6.2 etc.). However, now a pre-release alpha tag is being used instead (1.6.0-alpha2 -> 1.6.0-alpha3 -> 1.6.0-alpha4 etc.).

As such, we need to correct the conan package release versions to align with upstream.

This change will have ripple effects for all developers, dependent packages, and CI jobs. Developers will need to purge `up-core-api` from their local cache.